### PR TITLE
Fixed Spelling Mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 2. Update params.yaml
 3. Update entity
 4. Update the configuration manager in src config
-5. update the conponents
+5. update the components
 6. update the pipeline
 7. update the main.py
 8. update the app.py

--- a/README.md
+++ b/README.md
@@ -42,10 +42,7 @@ pip install -r requirements.txt
 python app.py
 ```
 
-Now,
-```bash
-open up you local host and port
-```
+Now, open up you local host and port
 
 
 ```bash


### PR DESCRIPTION
There was one spelling error in `README.md` where `conponents` <-> `components` as well as there was a Instruction in backticks.

```bash 
open up you local host and port
```
was changed to **Now, open up you local host and port**.

*Please review the change and if you find them helpful then merge this pull request.*
*Thanks.*